### PR TITLE
Do not buffer logging.

### DIFF
--- a/lib/raygun/app_builder.rb
+++ b/lib/raygun/app_builder.rb
@@ -252,6 +252,10 @@ RUBY
       copy_file 'Guardfile_customized', 'Guardfile'
     end
 
+    def setup_logging
+      inject_into_file 'config.ru', "$stdout.sync = true\n", before: 'run ExampleApp::Application'
+    end
+
     def setup_stylesheets
       remove_file 'app/assets/stylesheets/application.css'
       directory   '_app/assets/stylesheets', 'app/assets/stylesheets'

--- a/lib/raygun/generators/app_generator.rb
+++ b/lib/raygun/generators/app_generator.rb
@@ -120,6 +120,7 @@ module Raygun
       build :setup_simple_form
       build :setup_authentication
       build :setup_guard
+      build :setup_logging
     end
 
     def setup_stylesheets


### PR DESCRIPTION
So that heroku realtime logging and foreman's console output can show logs. Fixes #23.
