### PR TITLE
Change hash_syntax problem

### DIFF
--- a/bin/raygun
+++ b/bin/raygun
@@ -1,6 +1,6 @@
 #!/usr/bin/env ruby
 require File.expand_path(File.join('..', 'lib', 'raygun', 'raygun'), File.dirname(__FILE__))
-
+Raygun::AppGenerator.launch_path(Dir.pwd)
 templates_root = File.expand_path(File.join('..', 'templates'), File.dirname(__FILE__))
 Raygun::AppGenerator.source_root templates_root
 Raygun::AppGenerator.source_paths << Rails::Generators::AppGenerator.source_root << templates_root

--- a/lib/raygun/app_builder.rb
+++ b/lib/raygun/app_builder.rb
@@ -285,7 +285,9 @@ RUBY
     end
 
     def convert_to_19_hash_syntax
-      run 'hash_syntax -n'
+      inside(Raygun::AppGenerator.launch_path) do
+        run "find #{destination_root} -name '*.rb' | xargs hash_syntax -n"
+      end
     end
 
     def consistent_quoting

--- a/lib/raygun/generators/app_generator.rb
+++ b/lib/raygun/generators/app_generator.rb
@@ -2,6 +2,12 @@ module Raygun
   class AppGenerator < Rails::Generators::AppGenerator
     include Raygun::RubyVersionHelpers
 
+    # set and get raygun launch path
+    def self.launch_path(path=nil)
+      @_launch_path = path if path
+      @_launch_path
+    end
+
     class_option :database, type: :string, aliases: '-d', default: 'postgresql',
                  desc: "Preconfigure for selected database (options: #{DATABASES.join('/')})"
 


### PR DESCRIPTION
If you've already installed rails dependencies, you won't see this problem. This fix makes hash_syntax execute from the raygun working directory (and gemspec) to your target directory, wherever it may be.
