### PR TITLE
hash_syntax directory change

### DIFF
--- a/lib/raygun/app_builder.rb
+++ b/lib/raygun/app_builder.rb
@@ -285,8 +285,9 @@ RUBY
     end
 
     def convert_to_19_hash_syntax
+      original_destination_root = destination_root
       inside(Raygun::AppGenerator.launch_path) do
-        run "find #{destination_root} -name '*.rb' | xargs hash_syntax -n"
+        run "find #{original_destination_root} -name '*.rb' | xargs hash_syntax -n"
       end
     end
 


### PR DESCRIPTION
Raygun app generator launch path changes destination_root. We need to store the original destination root to syntactify.
