### PR TITLE
Users table should have a unique index on the email column

### DIFF
--- a/app_prototype/db/migrate/20121128215324_sorcery_core.rb
+++ b/app_prototype/db/migrate/20121128215324_sorcery_core.rb
@@ -9,6 +9,8 @@ class SorceryCore < ActiveRecord::Migration
 
       t.timestamps
     end
+
+    add_index :users, :email, unique: true
   end
 
   def self.down

--- a/app_prototype/db/schema.rb
+++ b/app_prototype/db/schema.rb
@@ -46,6 +46,7 @@ ActiveRecord::Schema.define(:version => 20121128215337) do
   end
 
   add_index "users", ["activation_token"], :name => "index_users_on_activation_token"
+  add_index "users", ["email"], :name => "index_users_on_email", :unique => true
   add_index "users", ["last_logout_at", "last_activity_at"], :name => "index_users_on_last_logout_at_and_last_activity_at"
   add_index "users", ["remember_me_token"], :name => "index_users_on_remember_me_token"
   add_index "users", ["reset_password_token"], :name => "index_users_on_reset_password_token"


### PR DESCRIPTION
The migration generated by raygun does not create an index on the email column, and it probably should.
