### PR TITLE
Read the session cookie store key from the environment

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 0.0.19 [2013-01-??]
+
+* Pull the rails secret token from the environment so it can be easily set in server environments.
+
 ## 0.0.18 [2013-01-24]
 
 * Support generating an app in the current directory.

--- a/app_prototype/.env
+++ b/app_prototype/.env
@@ -4,3 +4,4 @@
 # http://ddollar.github.com/foreman/#ENVIRONMENT
 
 PORT=3000
+SECRET_TOKEN=SUPER_SECRET_TOKEN_REPLACE_ME_TODO

--- a/app_prototype/config/initializers/secret_token.rb
+++ b/app_prototype/config/initializers/secret_token.rb
@@ -4,4 +4,4 @@
 # If you change this key, all old signed cookies will become invalid!
 # Make sure the secret is at least 30 characters and all random,
 # no regular words or you'll be exposed to dictionary attacks.
-AppPrototype::Application.config.secret_token = 'SUPER_SECRET_TOKEN_REPLACE_ME_TODO'
+AppPrototype::Application.config.secret_token = ENV['SECRET_TOKEN']

--- a/bin/raygun
+++ b/bin/raygun
@@ -46,7 +46,7 @@ module Raygun
 
     def generate_tokens
       Dir.chdir(app_dir) do
-        `sed -i '' 's/SUPER_SECRET_TOKEN_REPLACE_ME_TODO/#{SecureRandom.hex(128)}/' #{app_dir}/config/initializers/secret_token.rb`
+        `sed -i '' 's/SUPER_SECRET_TOKEN_REPLACE_ME_TODO/#{SecureRandom.hex(128)}/' #{app_dir}/.env`
       end
     end
 


### PR DESCRIPTION
Read the session cookie store key from the environment, defaulting to what is set in .env. It'll work OOTB in development and require a single command before working on heroku.
