### PR TITLE
Disable threadsafe! mode in production environments when running raks tasks

### DIFF
--- a/app_prototype/config/environments/acceptance.rb
+++ b/app_prototype/config/environments/acceptance.rb
@@ -52,7 +52,7 @@ AppPrototype::Application.configure do
   # config.action_mailer.raise_delivery_errors = false
 
   # Enable threaded mode
-  config.threadsafe!
+  config.threadsafe! unless $rails_rake_task
 
   # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
   # the I18n.default_locale when a translation can not be found)

--- a/app_prototype/config/environments/production.rb
+++ b/app_prototype/config/environments/production.rb
@@ -52,7 +52,7 @@ AppPrototype::Application.configure do
   # config.action_mailer.raise_delivery_errors = false
 
   # Enable threaded mode
-  config.threadsafe!
+  config.threadsafe! unless $rails_rake_task
 
   # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
   # the I18n.default_locale when a translation can not be found)


### PR DESCRIPTION
Rake tasks cannot access models when threadsafe mode is enabled. Rake sets a global variable that can be checked to disable threadsafe mode when running tasks.

See: https://github.com/rails/rails/issues/2662

Change:
    `config.threadsafe!`
To:
    `config.threadsafe! unless $rails_rake_task`
