### PR TITLE
Remove the generate_tokens, no longer needed

### DIFF
--- a/bin/raygun
+++ b/bin/raygun
@@ -40,14 +40,7 @@ module Raygun
     end
 
     def configure_new_app
-      generate_tokens
       update_ruby_version
-    end
-
-    def generate_tokens
-      Dir.chdir(app_dir) do
-        `sed -i '' 's/SUPER_SECRET_TOKEN_REPLACE_ME_TODO/#{SecureRandom.hex(128)}/' #{app_dir}/.env`
-      end
     end
 
     def update_ruby_version


### PR DESCRIPTION
I see that the last remnant of the SUPER_SECRET token was removed in
3c80a94 and see no other reference to it in use.

Another option on this, the hardcoded token 'AWAbYFxfy5SxropZl5yIiNiE2bv3lJ7nLcreGI9p' could be set to the old SUPER_SECRET placeholder so that you ensure unique generates in case anybody accidentally pushes to prod without the ENV setup.  I'm not sure if it needs to be set to that string for a reason, or any string like that would do.
