### PR TITLE
Upgrade to Rails 3.2.12.

### DIFF
--- a/app_prototype/Gemfile
+++ b/app_prototype/Gemfile
@@ -4,7 +4,7 @@ source 'https://rubygems.org'
 ruby '1.9.3'
 
 gem 'thin'
-gem 'rails', '~> 3.2.11'
+gem 'rails', '~> 3.2.12'
 gem 'slim-rails'
 gem 'jquery-rails'
 gem 'sorcery'


### PR DESCRIPTION
Raygun is currently generating Rails 3.2.11 sites, but 3.2.11 has security vulnerabilities; see:

http://weblog.rubyonrails.org/2013/2/11/SEC-ANN-Rails-3-2-12-3-1-11-and-2-3-17-have-been-released/
