### PR TITLE
Switch to Unicorn

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## 0.0.28 []
 
+* Use unicorn by default instead of thin, as per heroku's recommendation.
 * Suppress schema dumping unless run in development mode to eliminate pg_dump errors on heroku during db:migrate.
 * Tweak mailcacher configuration so that it only sets smtp_settings when mailchacher is running.
 

--- a/rails_32/.env
+++ b/rails_32/.env
@@ -4,3 +4,5 @@
 # http://ddollar.github.com/foreman/#ENVIRONMENT
 
 PORT=3000
+UNICORN_WORKERS=3
+UNICORN_BACKLOG=16

--- a/rails_32/Gemfile
+++ b/rails_32/Gemfile
@@ -3,8 +3,8 @@ source 'https://rubygems.org'
 # Heroku uses the ruby version to configure your application's runtime.
 ruby '1.9.3'
 
-gem 'thin'
-gem 'rails', '~> 3.2.13.rc1'
+gem 'unicorn'
+gem 'rails', '~> 3.2.13'
 gem 'slim-rails'
 gem 'jquery-rails'
 gem 'sorcery'

--- a/rails_32/Procfile
+++ b/rails_32/Procfile
@@ -1,2 +1,2 @@
-web:    rails server -p $PORT
+web:    bundle exec unicorn -c ./config/unicorn.rb
 #worker: bundle exec rake jobs:work

--- a/rails_32/config/unicorn.rb
+++ b/rails_32/config/unicorn.rb
@@ -1,0 +1,27 @@
+# http://unicorn.bogomips.org/
+# https://blog.heroku.com/archives/2013/2/27/unicorn_rails
+# http://devblog.thinkthroughmath.com/blog/2013/02/27/managing-request-queuing-with-rails-on-heroku/
+
+listen           ENV['PORT'], backlog: Integer(ENV['UNICORN_BACKLOG'] || 16)
+worker_processes Integer(ENV['UNICORN_WORKERS'] || 3)
+timeout          30
+preload_app      true
+
+before_fork do |server, worker|
+  Signal.trap 'TERM' do
+    puts 'Unicorn master intercepting TERM and sending myself QUIT instead.'
+    Process.kill 'QUIT', Process.pid
+  end
+
+  defined?(ActiveRecord::Base) and
+    ActiveRecord::Base.connection.disconnect!
+end
+
+after_fork do |server, worker|
+  Signal.trap 'TERM' do
+    puts 'Unicorn worker intercepting TERM and doing nothing. Wait for master to send QUIT.'
+  end
+
+  defined?(ActiveRecord::Base) and
+    ActiveRecord::Base.establish_connection
+end


### PR DESCRIPTION
Heroku now recommends unicorn as the default app server.

https://blog.heroku.com/archives/2013/3/13/running_rails_on_heroku_update

https://blog.heroku.com/archives/2013/2/27/unicorn_rails

Be sure to set a small backlog: http://devblog.thinkthroughmath.com/blog/2013/02/27/managing-request-queuing-with-rails-on-heroku/
