### PR TITLE
Removing ActiveRecord::Base.shared_connection

### DIFF
--- a/rails_32/Gemfile
+++ b/rails_32/Gemfile
@@ -30,6 +30,7 @@ group :test, :development do
   gem 'rspec-rails'
   gem 'capybara'
   gem 'capybara-email'
+  gem 'database_cleaner'
   gem 'factory_girl_rails'
   gem 'jasminerice'
   gem 'timecop'

--- a/rails_32/spec/spec_helper.rb
+++ b/rails_32/spec/spec_helper.rb
@@ -42,7 +42,7 @@ RSpec.configure do |config|
   # If you're not using ActiveRecord, or you'd prefer not to run each of your
   # examples within a transaction, remove the following line or assign false
   # instead of true.
-  config.use_transactional_fixtures = true
+  config.use_transactional_fixtures = false
 
   # If true, the base class of anonymous controllers will be inferred
   # automatically. This will be the default behavior in future versions of
@@ -59,22 +59,6 @@ RSpec.configure do |config|
   #     --seed 1234
   config.order = "random"
 end
-
-# Forces all threads to share the same connection. This works on
-# Capybara because it starts the web server in a thread.
-#
-# http://blog.plataformatec.com.br/2011/12/three-tips-to-improve-the-performance-of-your-test-suite/
-
-class ActiveRecord::Base
-  mattr_accessor :shared_connection
-  @@shared_connection = nil
-
-  def self.connection
-    @@shared_connection || retrieve_connection
-  end
-end
-
-ActiveRecord::Base.shared_connection = ActiveRecord::Base.connection
 
 # Turn down the logging while testing.
 Rails.logger.level = 4

--- a/rails_32/spec/support/database_cleaner.rb
+++ b/rails_32/spec/support/database_cleaner.rb
@@ -1,0 +1,21 @@
+RSpec.configure do |config|
+  config.before(:suite) do
+    DatabaseCleaner.clean_with(:truncation)
+  end
+
+  config.before(:each) do
+    DatabaseCleaner.strategy = :transaction
+  end
+
+  config.before(:each, js: true) do
+    DatabaseCleaner.strategy = :truncation
+  end
+
+  config.before(:each) do
+    DatabaseCleaner.start
+  end
+
+  config.after(:each) do
+    DatabaseCleaner.clean
+  end
+end


### PR DESCRIPTION
Using Database Cleaner & truncation strategy for js tests
