### PR TITLE
Generated app should default to the ruby version/patchlevel that was used to execute raygun

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,7 @@
 
 * For Heroku, default to serving static assets and the logger is synchronous by default (we don't have to set it) (#103).
 * Less duplication in acceptance.rb, since it's basicially the same as production.rb.
+* Fixed a regression where new apps might be configured with a non-existent ruby (#104).
 
 ## 0.0.30 [2013-06-14]
 

--- a/bin/raygun
+++ b/bin/raygun
@@ -56,7 +56,7 @@ module Raygun
     end
 
     def update_ruby_version
-      prototype_ruby_patch_level  = File.read(File.expand_path('../../.ruby-version', __FILE__)).strip
+      prototype_ruby_patch_level  = File.read(File.expand_path("../../#{prototype}/.ruby-version", __FILE__)).strip
       prototype_ruby_version      = prototype_ruby_patch_level.match(/(\d\.\d\.\d).*/)[1]
       current_ruby_version        = RUBY_VERSION
       current_ruby_patch_level    = "#{RUBY_VERSION}-p#{RUBY_PATCHLEVEL}"
@@ -77,7 +77,7 @@ module Raygun
 
     def print_plan
 
-      project_template = prototype == 'rails_32' ? '3.2' : '4'
+      project_template = (prototype == 'rails_32') ? '3.2' : '4'
 
       puts '     ____ '.colorize(:light_yellow)
       puts '    / __ \____ ___  ______ ___  ______ '.colorize(:light_yellow)


### PR DESCRIPTION
... since that's the only ruby we know for sure the user has installed, and we don't ant to force them to install a new ruby / futz with configuration before using their new app.

This is a regression.
