### PR TITLE
RSpec's rake task patterns use globs, and don't work with regular expressions as one might expect

### DIFF
--- a/rails_40/lib/tasks/spec.rake
+++ b/rails_40/lib/tasks/spec.rake
@@ -5,7 +5,9 @@ begin
   namespace :spec do
     desc "Run the code examples in spec/ except those in spec/features"
     RSpec::Core::RakeTask.new('without_features' => 'db:test:prepare') do |t|
-      t.pattern = "./spec/[^features]**/**/*_spec.rb"
+      file_list = FileList['spec/**/*_spec.rb'].exclude("spec/features/**/*_spec.rb")
+
+      t.pattern = file_list
     end
   end
 


### PR DESCRIPTION
Ran into this issue on wonderful - we've got a bunch of specs running in guard, but not running under rake. Turns out this is the root cause.

See: http://murphyslaw.github.io/blog/2012/04/06/run-specs-excluding-integration-specs/
