### PR TITLE
bootstrap 3 compatibility fixes and use icons with all scaffold buttons

### DIFF
--- a/rails_40/app/assets/stylesheets/_navbar.less
+++ b/rails_40/app/assets/stylesheets/_navbar.less
@@ -1,3 +1,7 @@
 // Navbar
 
 body { padding-top: 70px; }
+
+.nav a .glyphicon, form button.btn .glyphicon {
+  padding-right: .2rem;
+}

--- a/rails_40/app/helpers/application_helper.rb
+++ b/rails_40/app/helpers/application_helper.rb
@@ -1,8 +1,42 @@
 module ApplicationHelper
 
+  # create text with an icon to the left for bootstrap menus and buttons
+  def text_with_icon(text, icon_name)
+    raw("#{icon(icon_name)} #{text}")
+  end
+
+  # generate a standard bootstrap glyphicon
+  def icon(name)
+    content_tag(:span, nil, class: "glyphicon glyphicon-#{name}")
+  end
+
+  # action name to use for the primary submit button on scaffold-created CRUD forms
+  def btn_action_prefix
+    case action_name
+      when 'new', 'create'
+        'Create'
+      when 'edit', 'update'
+        'Update'
+      else
+        nil
+    end
+  end
+
+  # bootstrap icon name to use for the primary submit button on scaffold-created forms
+  def action_icon_name
+    case action_name
+      when 'new', 'create'
+        'plus'
+      when 'edit', 'update'
+        'edit'
+      else
+        nil
+    end
+  end
+
   def alert_class(alert_type)
     alert_type = {
-      alert: 'error',
+      alert: 'danger',
       notice: 'info'
     }.fetch(alert_type, alert_type.to_s)
     "alert-#{alert_type}"

--- a/rails_40/app/views/layouts/application.html.slim
+++ b/rails_40/app/views/layouts/application.html.slim
@@ -24,16 +24,18 @@ html
             /      = current_user.email
             /      b.caret
             /    ul.dropdown-menu
-            /      li= link_to 'Sign Out', sign_out_path
+            /      li= link_to text_with_icon('Sign Out', 'log-out'), sign_out_path
             / - else
-            /  li= link_to 'Sign In', sign_in_path
+            /  li= link_to text_with_icon('Sign In', 'log-in'), sign_in_path
 
       .container
         - flash.each do |name, msg|
-          = content_tag :div, raw(msg), class: "alert #{alert_class(name)}"
+          .alert.alert-dismissable class=alert_class(name)
+            button.close type='button' data-dismiss='alert' aria-hidden='true' &times;
+            =raw(msg)
         = yield
         .push
 
       footer
         .container
-          p &copy; 2013 All rights reserved.
+          p &copy; #{ Time.now.year.to_s } All rights reserved.

--- a/rails_40/lib/templates/slim/scaffold/_form.html.slim
+++ b/rails_40/lib/templates/slim/scaffold/_form.html.slim
@@ -7,7 +7,8 @@
 <%- end -%>
 
   .form-actions
-    = f.button :submit, class: 'btn btn-primary'
+    = button_tag(type: 'submit', class: 'btn btn-primary') do
+      =text_with_icon("#{btn_action_prefix} <%= singular_table_name.humanize %>", action_icon_name)
     '
-    = link_to 'Back', <%= index_helper %>_path, class: 'btn'
+    = link_to text_with_icon('Back', 'chevron-left'), <%= index_helper %>_path, class: 'btn btn-default'
 

--- a/rails_40/lib/templates/slim/scaffold/index.html.slim
+++ b/rails_40/lib/templates/slim/scaffold/index.html.slim
@@ -20,10 +20,11 @@ table.table.table-striped
 <% end -%>
       td
         /- if can? :edit, <%= singular_table_name %>
-          = link_to 'Edit', edit_<%= singular_table_name %>_path(<%= singular_table_name %>), class: 'btn btn-mini'
+          = link_to text_with_icon('Edit', 'edit'), edit_<%= singular_table_name %>_path(<%= singular_table_name %>), class: 'btn btn-default btn-xs'
           '
         /- if can? :destroy, <%= singular_table_name %>
-          = link_to 'Destroy', <%= singular_table_name %>_path(<%= singular_table_name %>), method: :delete, data: { confirm: "Are you sure?" }, class: 'btn btn-mini btn-danger'
+          = link_to text_with_icon('Destroy', 'remove'), <%= singular_table_name %>_path(<%= singular_table_name %>), \
+                    method: :delete, data: { confirm: "Are you sure?" }, class: 'btn btn-default btn-xs btn-danger'
 
 /- if can? :create, <%= singular_table_name.classify %>
-  = link_to 'New <%= human_name %>', new_<%= singular_table_name %>_path, class: 'btn btn-primary'
+  = link_to text_with_icon(''New <%= human_name %>', 'plus'), new_<%= singular_table_name %>_path, class: 'btn btn-primary'

--- a/rails_40/lib/templates/slim/scaffold/show.html.slim
+++ b/rails_40/lib/templates/slim/scaffold/show.html.slim
@@ -8,10 +8,11 @@ dl
 <% end -%>
 
 /- if can?(:edit, @<%= singular_table_name %>)
-  = link_to 'Edit', edit_<%= singular_table_name %>_path(@<%= singular_table_name %>), class: 'btn'
+  = link_to text_with_icon('Edit', 'edit'), edit_<%= singular_table_name %>_path(@<%= singular_table_name %>), class: 'btn btn-default'
   '
-= link_to 'Back', <%= index_helper %>_path, class: 'btn'
+= link_to text_with_icon('Back', 'chevron-left'), <%= index_helper %>_path, class: 'btn btn-default'
 
 /- if can?(:destroy, @<%= singular_table_name %>)
   '
-  = link_to'Destroy', <%= singular_table_name %>_path(@<%= singular_table_name %>), method: :delete, data: { confirm: "Are you sure?" }, class: 'btn btn-danger'
+  = link_to text_with_icon('Destroy', 'remove'), <%= singular_table_name %>_path(@<%= singular_table_name %>), \
+            method: :delete, data: { confirm: "Are you sure?" }, class: 'btn btn-danger'


### PR DESCRIPTION
- updated some old bootstrap css classes to bootstrap 3 standards
- helpers to easily create bootstrap 3 glyphicon buttons
- scaffold templates now include glyphicon buttons
- standard bootstrap alert containers now dismissable
- :copyright:  year in footer now dynamic  
- only made these changes to the rails 4 template since the rails 3 template has not been updated to bootstrap 3

if you don't want the icon stuff I can re-create with just the bootstrap 3 css fixes!
