### PR TITLE
Add -p, —prototype command line option to select different repositories from the Carbon Five default

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,9 @@ best practices baked right in. Spend less time configuring and more building coo
 Raygun generates Rails 4 projects by copying this [sample app](https://github.com/carbonfive/raygun-rails4)
 and massaging it gently into shape.
 
+Raygun now also allows you to specify your own prototype instead of the default sample app. See below
+for details.
+
 Major tools/libraries:
 
 * Rails 4.0
@@ -53,6 +56,17 @@ To run your new application's specs or fire up its server, you'll need to meet t
 
 The generated app will be configured to use the ruby version that was used to invoke raygun. If you're using
 another ruby, just change the ```Gemfile``` and ```.ruby-version``` as necessary.
+
+###Using a custom template
+
+If you invoke raygun with the "-p" option, you can specify your own github repository.
+
+    $ raygun -p githubid/repo your-project
+    
+The repository must:
+
+* Have been tagged. Raygun chooses the "greatest" tag and downloads the repository as of that tag. 
+* Not have any binary files. Raygun runs a 'sed' command on all files, which will fail on binaries, such as jar files.
 
 ## Usage
 

--- a/lib/raygun/raygun.rb
+++ b/lib/raygun/raygun.rb
@@ -10,6 +10,7 @@ require_relative 'version'
 
 module Raygun
   class Runner
+    CARBONFIVE_REPO = 'carbonfive/raygun-rails4'
     attr_accessor :target_dir, :app_dir, :app_name, :dash_name, :snake_name, :camel_name, :title_name, :prototype_repo
 
     def initialize(target_dir, prototype_repo)
@@ -150,6 +151,14 @@ module Raygun
     end
 
     def print_next_steps
+      if @prototype_repo == CARBONFIVE_REPO
+        print_next_steps_carbon_five
+      else
+        print_next_steps_for_custom_repo
+      end
+    end
+    
+    def print_next_steps_carbon_five
       puts ""
       puts "Zap! Your application is ready. Next steps...".colorize(:yellow)
       puts ""
@@ -169,6 +178,13 @@ module Raygun
       puts "$".colorize(:blue) + " open http://0.0.0.0:3000".colorize(:light_blue)
       puts ""
       puts "Enjoy your Carbon Five flavored Rails application!".colorize(:yellow)
+    end
+    
+    def print_next_steps_for_custom_repo
+      puts ""
+      puts "Zap! Your application is ready.".colorize(:yellow)
+      puts ""
+      puts "Enjoy your raygun generated application!".colorize(:yellow)
     end
 
     protected
@@ -247,7 +263,7 @@ module Raygun
 
       options = OpenStruct.new
       options.target_dir     = nil
-      options.prototype_repo = 'carbonfive/raygun-rails4'
+      options.prototype_repo = CARBONFIVE_REPO
 
       parser = OptionParser.new do |opts|
         opts.banner = "Usage: raygun [options] NEW_APP_DIRECTORY"


### PR DESCRIPTION
- Enable the option that was there
- In fetch_latest_tag:
  - Use parameter to method rather than instance variable for repo
  - Check that we get a “200” response - otherwise error out and let user know the response code
  - Check that we have at least one tag - otherwise error out and let user know about tags

If you wish, you can test this with my fork: drogar/raygun-rails4 - The latest version with kaminari is tagged.
