### PR TITLE
Rename 'raygun-rails4' to 'raygun-rails'

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,7 @@
 ## 0.9.2 [2013-]
 
 * Support custom project templates with the -p command line arg (#122, thanks @drogar!).
+* Remove the stranded and useless .raygun-version from the generated app.
 
 ## 0.9.1 [2013-11-12]
 
@@ -11,9 +12,9 @@
 
 ## 0.9.0 [2013-11-11]
 
-Note: All future changes to the application prototype (sample app) will be made in the [raygun-rails4](https://github.com/carbonfive/raygun-rails4) repo.
+Note: All future changes to the application prototype (sample app) will be made in the [raygun-rails](https://github.com/carbonfive/raygun-rails) repo.
 
-* Raygun no longer bundles the application prototype, it's fetched from github (https://github.com/carbonfive/raygun-rails4) instead (#112).
+* Raygun no longer bundles the application prototype, it's fetched from github (https://github.com/carbonfive/raygun-rails) instead (#112).
 * Drop support for Rails 3 (#116).
 * Better bootstrap 3 support (#115, thanks @felafelwaffle!).
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 Rails application generator that builds a new project skeleton configured with Carbon Five preferences and
 best practices baked right in. Spend less time configuring and more building cool features.
 
-Raygun generates Rails 4 projects by copying this [sample app](https://github.com/carbonfive/raygun-rails4)
+Raygun generates Rails 4 projects by copying this [sample app](https://github.com/carbonfive/raygun-rails)
 and massaging it gently into shape.
 
 Alternatively, Raygun allows you to specify your own prototype instead of the default sample app. See below
@@ -24,7 +24,7 @@ Major tools/libraries:
 * Jasmine
 * SimpleCov
 * Guard (rspec, jasmine, livereload)
-* And many tweaks, patterns and common recipes (see [raygun-rails4](https://github.com/carbonfive/raygun-rails4) for all the details).
+* And many tweaks, patterns and common recipes (see [raygun-rails](https://github.com/carbonfive/raygun-rails) for all the details).
 
 Raygun includes generator templates for controllers, views, and specs so that generated code follows best
 practices. For example, view generation produces bootstrap compatible markup and rspec specs use factory
@@ -80,7 +80,7 @@ covered (see above).
 
 ## Using a Custom Project Template
 
-The default is to use the project at [carbonfive/raygun-rails4](https://github.com/carbonfive/raygun-rails4) as a
+The default is to use the project at [carbonfive/raygun-rails](https://github.com/carbonfive/raygun-rails) as a
 starting point. You can use another repo as the project template with the ```-p``` command line option.
 
 If you invoke raygun with the ```-p``` option, you can specify your own github repository.
@@ -97,7 +97,7 @@ If your project template requires a minimum version of raygun, include the versi
 
 ## Internal Mechanics
 
-Raygun fetches the greatest tag from the [carbonfive/raygun-rails4](https://github.com/carbonfive/raygun-rails4)
+Raygun fetches the greatest tag from the [carbonfive/raygun-rails](https://github.com/carbonfive/raygun-rails)
 repo, unless it already has it cached in ~/.raygun, extracts the contents of the tarball, and runs a series of
 search-and-replaces on the code to customize it accordingly.
 

--- a/lib/raygun/raygun.rb
+++ b/lib/raygun/raygun.rb
@@ -10,7 +10,7 @@ require_relative 'version'
 
 module Raygun
   class Runner
-    CARBONFIVE_REPO = 'carbonfive/raygun-rails4'
+    CARBONFIVE_REPO = 'carbonfive/raygun-rails'
     attr_accessor :target_dir, :app_dir, :app_name, :dash_name, :snake_name, :camel_name, :title_name, :prototype_repo
 
     def initialize(target_dir, prototype_repo)
@@ -197,7 +197,7 @@ module Raygun
 
     protected
 
-    # Fetch the tags for the repo (e.g. 'carbonfive/raygun-rails4') and return the latest as JSON.
+    # Fetch the tags for the repo (e.g. 'carbonfive/raygun-rails') and return the latest as JSON.
     def fetch_latest_tag(repo)
       url          = "https://api.github.com/repos/#{repo}/tags"
       uri          = URI.parse(url)
@@ -279,7 +279,7 @@ module Raygun
         opts.on('-h', '--help', "Show raygun usage") do
           usage_and_exit(opts)
         end
-        opts.on('-p', '--prototype [github_repo]', "Prototype github repo (e.g. carbonfive/raygun-rails4).") do |prototype|
+        opts.on('-p', '--prototype [github_repo]', "Prototype github repo (e.g. carbonfive/raygun-rails).") do |prototype|
           options.prototype_repo = prototype
         end
       end


### PR DESCRIPTION
We're not really going to support generating multiple versions of Rails. Raygun generates a modern, up-to-date rails application. I would like to do this rename and release a new gem before making any announcements about the new version of raygun.
