### PR TITLE
Rename directories and files with “app_prototype” in their names

### DIFF
--- a/lib/raygun/raygun.rb
+++ b/lib/raygun/raygun.rb
@@ -117,6 +117,10 @@ module Raygun
           shell "find . -type f -print | xargs #{sed_i} 's/#{proto_name}/#{new_name}/g'"
         end
       end
+
+      %w(d f).each do |find_type|
+        shell "find . -depth -type #{find_type} -name '*app_prototype*' -exec bash -c 'mv $0 ${0/app_prototype/#{snake_name}}' {} \\;"
+      end
     end
 
     def configure_new_app


### PR DESCRIPTION
In response to the discussion in #132, this PR adds support for renaming files and directories with "app_prototype" in their names. It gives Raygun the ability to work with Ruby projects where the project name is part of its file/directory structure (e.g. with files in `lib/my_project/`).

The rename uses `find` and execs bash to use its substring replacement to rename the files. It runs a `find` with the `-depth` option to run depth-first, and runs it in two passes, on directories first, and then on files. Doing this ensures that we're operating on a relevant list of results and it doesn't try and rename files in already renamed (and therefore stale) directories.

I've tested this command on both OS X and Linux and it seems good on both.