### PR TITLE
Allow Directories With Spaces

### DIFF
--- a/lib/raygun/raygun.rb
+++ b/lib/raygun/raygun.rb
@@ -95,7 +95,7 @@ module Raygun
     def copy_prototype
       FileUtils.mkdir_p(app_dir)
 
-      shell "tar xfz #{@prototype} -C #{app_dir}"
+      shell "tar xfz #{@prototype} -C \"#{app_dir}\""
 
       # Github includes an extra directory layer in the tag tarball.
       extraneous_dir = Dir.glob("#{app_dir}/*").first


### PR DESCRIPTION
Fixed an error where directories with spaces in the name were impossible to use. (I know spacename directories aren't pretty, but...)