### PR TITLE
Fix for renaming directories: run find/rename commands inside the app directory

### DIFF
--- a/lib/raygun/raygun.rb
+++ b/lib/raygun/raygun.rb
@@ -116,10 +116,10 @@ module Raygun
         }.each do |proto_name, new_name|
           shell "find . -type f -print | xargs #{sed_i} 's/#{proto_name}/#{new_name}/g'"
         end
-      end
 
-      %w(d f).each do |find_type|
-        shell "find . -depth -type #{find_type} -name '*app_prototype*' -exec bash -c 'mv $0 ${0/app_prototype/#{snake_name}}' {} \\;"
+        %w(d f).each do |find_type|
+          shell "find . -depth -type #{find_type} -name '*app_prototype*' -exec bash -c 'mv $0 ${0/app_prototype/#{snake_name}}' {} \\;"
+        end
       end
     end
 


### PR DESCRIPTION
Hi again!

I've just published a (temporary) fork of raygun (https://rubygems.org/gems/rraygun) so members of the public could clone our rodakase-skeleton project and have the `app_prototype` directories renamed properly.

In testing this, I discovered a bug with my earlier PR :grimacing: – the `find` command I'm using to rename the directories wasn't being run inside the newly create prototype app's own directory.

I've pushed commands up inside the `chdir` block now and everything's good.

Thanks again for pulling in this feature!