### PR TITLE
Use `heroku local` instead of `foreman start`

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,13 +65,13 @@ Once your project is baked out, you can easily kick the wheels. Be sure that you
 covered (see above).
 
     $ cd your-project
-    $ ./bin/setup
+    $ bin/setup
 
     # Run the specs, they should all pass
-    $ rake
+    $ bin/rake
 
     # Fire up the app and open it in a browser
-    $ foreman start
+    $ heroku local
     $ open http://localhost:3000
 
 ## Using a Custom Project Template
@@ -83,7 +83,7 @@ If you invoke raygun with the `-p` option, you can specify your own github repos
 
     $ raygun -p githubid/repo your-project
 
-Or 
+Or
 
     $ raygun -p githubid/repo your-project#new-branch-name
 

--- a/lib/raygun/raygun.rb
+++ b/lib/raygun/raygun.rb
@@ -184,13 +184,13 @@ module Raygun
       puts ""
       puts "# Install updated dependencies and prepare the database".colorize(:light_green)
       puts "$".colorize(:blue) + " cd #{target_dir}".colorize(:light_blue)
-      puts "$".colorize(:blue) + " ./bin/setup".colorize(:light_blue)
+      puts "$".colorize(:blue) + " bin/setup".colorize(:light_blue)
       puts ""
       puts "# Run the specs (they should all pass)".colorize(:light_green)
-      puts "$".colorize(:blue) + " rake".colorize(:light_blue)
+      puts "$".colorize(:blue) + " bin/rake".colorize(:light_blue)
       puts ""
       puts "# Run the app and check things out".colorize(:light_green)
-      puts "$".colorize(:blue) + " foreman start".colorize(:light_blue)
+      puts "$".colorize(:blue) + " heroku local".colorize(:light_blue)
       puts "$".colorize(:blue) + " open http://localhost:3000".colorize(:light_blue)
       puts ""
       puts "Enjoy your Carbon Five flavored Rails application!".colorize(:yellow)


### PR DESCRIPTION
This commit changes the instructions that are printed once a raygun project is generated, to bring it in line with latest practices.

First, `bin/rake` is preferable to `rake` (i.e. if `./bin` is not in the `$PATH`). The binstub ensures that the right version of rake is used, and also has performance benefits due to spring. This also fixes problems like this:

```
$ rake
rake aborted!
Gem::LoadError: You have already activated rake 12.3.0, but your Gemfile requires rake 12.2.1. Prepending `bundle exec` to your command may solve this.
```

Second, `heroku local` is preferable to `foreman start`, as explained here: https://github.com/carbonfive/raygun-rails/pull/99

Finally, as a matter of style and brevity, use `bin/<command>` instead of `./bin/<command>`.