### PR TITLE
CLI: output version

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Gem Version](https://badge.fury.io/rb/raygun.png)](http://badge.fury.io/rb/raygun)
+[![Gem Version](https://badge.fury.io/rb/raygun.svg)](http://badge.fury.io/rb/raygun)
 <img src="https://raw.github.com/carbonfive/raygun/master/marvin.jpg" align="right"/>
 
 # Raygun

--- a/lib/raygun/raygun.rb
+++ b/lib/raygun/raygun.rb
@@ -245,6 +245,11 @@ module Raygun
         opts.on('-p', '--prototype [github_repo]', "Prototype github repo (e.g. carbonfive/raygun-rails).") do |prototype|
           options.prototype_repo = prototype
         end
+
+        opts.on('-v', '--version', 'Print the version number') do
+          puts Raygun::VERSION
+          exit 1
+        end
       end
 
       begin


### PR DESCRIPTION
Adds support for `-v` and `--version` to the CLI:

```bash
$ bin/raygun -v
1.0.4
```

Addresses https://github.com/carbonfive/raygun/issues/121.