### PR TITLE
Add bundler and rake development dependencies

### DIFF
--- a/raygun.gemspec
+++ b/raygun.gemspec
@@ -20,4 +20,7 @@ Gem::Specification.new do |gem|
   gem.executables   = gem.files.grep(%r{^bin/}).map { |f| File.basename(f) }
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
+
+  gem.add_development_dependency "bundler", "~> 2.0"
+  gem.add_development_dependency "rake", "~> 13.0"
 end


### PR DESCRIPTION
This project requires bundler and rake in order to build and release to rubygems (`rake release`). It is a good practice to list these kinds of build requirements as "development dependencies" in the gemspec.