### PR TITLE
Remove URI.encode, which is deprecated in Ruby 2.7

### DIFF
--- a/lib/raygun/template_repo.rb
+++ b/lib/raygun/template_repo.rb
@@ -65,12 +65,12 @@ module Raygun
     end
 
     def http_get(url)
-      uri          = URI.parse(url)
+      uri          = URI(url)
       http         = Net::HTTP.new(uri.host, uri.port)
       http.use_ssl = true
-      request      = Net::HTTP::Get.new(URI.encode(url))
+      request      = Net::HTTP::Get.new(uri)
 
-      response     = http.request(request)
+      http.request(request)
     end
   end
 end


### PR DESCRIPTION
This fixes the following warning when running raygun under Ruby 2.7.0:

```
warning: URI.escape is obsolete
```

We don't actually need to escape anything, because in practice a branch name should be simply appended to the GitHub URL as-is. For example, if the branch is `dependabot/bundler/pg-1.2.2`, then this URL is completely valid:

```
https://github.com/carbonfive/raygun-rails/archive/dependabot/bundler/pg-1.2.2.tar.gz
```

I confirmed this by testing locally.

Fixes #144 