### PR TITLE
Run autocorrections using c5-conventions/rubocop

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-source 'https://rubygems.org'
+source "https://rubygems.org"
 
 # Specify your gem's dependencies in raygun.gemspec
 gemspec

--- a/Rakefile
+++ b/Rakefile
@@ -1,1 +1,1 @@
-require 'bundler/gem_tasks'
+require "bundler/gem_tasks"

--- a/lib/colorize.rb
+++ b/lib/colorize.rb
@@ -5,41 +5,40 @@
 # want to add a gem dependency.
 
 class String
-
   #
   # Colors Hash
   #
   COLORS = {
-    :black          => 0,
-    :red            => 1,
-    :green          => 2,
-    :yellow         => 3,
-    :blue           => 4,
-    :magenta        => 5,
-    :cyan           => 6,
-    :white          => 7,
-    :default        => 9,
+    black: 0,
+    red: 1,
+    green: 2,
+    yellow: 3,
+    blue: 4,
+    magenta: 5,
+    cyan: 6,
+    white: 7,
+    default: 9,
 
-    :light_black    => 10,
-    :light_red      => 11,
-    :light_green    => 12,
-    :light_yellow   => 13,
-    :light_blue     => 14,
-    :light_magenta  => 15,
-    :light_cyan     => 16,
-    :light_white    => 17
+    light_black: 10,
+    light_red: 11,
+    light_green: 12,
+    light_yellow: 13,
+    light_blue: 14,
+    light_magenta: 15,
+    light_cyan: 16,
+    light_white: 17
   }
 
   #
   # Modes Hash
   #
   MODES = {
-    :default        => 0, # Turn off all attributes
+    default: 0, # Turn off all attributes
     #:bright        => 1, # Set bright mode
-    :underline      => 4, # Set underline mode
-    :blink          => 5, # Set blink mode
-    :swap           => 7, # Exchange foreground and background colors
-    :hide           => 8  # Hide text (foreground color would be the same as background)
+    underline: 4, # Set underline mode
+    blink: 5, # Set blink mode
+    swap: 7, # Exchange foreground and background colors
+    hide: 8  # Hide text (foreground color would be the same as background)
   }
 
   protected
@@ -47,15 +46,13 @@ class String
   #
   # Set color values in new string intance
   #
-  def set_color_parameters( params )
-    if (params.instance_of?(Hash))
+  def set_color_parameters(params)
+    if params.instance_of?(Hash)
       @color = params[:color]
       @background = params[:background]
       @mode = params[:mode]
       @uncolorized = params[:uncolorized]
       self
-    else
-      nil
     end
   end
 
@@ -77,22 +74,22 @@ class String
   #   puts "This is blue text on red".blue.on_red.blink
   #   puts "This is uncolorized".blue.on_red.uncolorize
   #
-  def colorize( params )
+  def colorize(params)
     return self unless STDOUT.isatty
 
     begin
-      require 'Win32/Console/ANSI' if RUBY_PLATFORM =~ /win32/
+      require "Win32/Console/ANSI" if RUBY_PLATFORM.match?(/win32/)
     rescue LoadError
-      raise 'You must gem install win32console to use colorize on Windows'
+      raise "You must gem install win32console to use colorize on Windows"
     end
 
     color_parameters = {}
 
-    if (params.instance_of?(Hash))
+    if params.instance_of?(Hash)
       color_parameters[:color] = COLORS[params[:color]]
       color_parameters[:background] = COLORS[params[:background]]
       color_parameters[:mode] = MODES[params[:mode]]
-    elsif (params.instance_of?(Symbol))
+    elsif params.instance_of?(Symbol)
       color_parameters[:color] = COLORS[params]
     end
 
@@ -100,14 +97,14 @@ class String
     color_parameters[:background] ||= @background ||= COLORS[:default]
     color_parameters[:mode] ||= @mode ||= MODES[:default]
 
-    color_parameters[:uncolorized] ||= @uncolorized ||= self.dup
+    color_parameters[:uncolorized] ||= @uncolorized ||= dup
 
     # calculate bright mode
     color_parameters[:color] += 50 if color_parameters[:color] > 10
 
     color_parameters[:background] += 50 if color_parameters[:background] > 10
 
-    "\033[#{color_parameters[:mode]};#{color_parameters[:color]+30};#{color_parameters[:background]+40}m#{color_parameters[:uncolorized]}\033[0m".set_color_parameters( color_parameters )
+    "\033[#{color_parameters[:mode]};#{color_parameters[:color] + 30};#{color_parameters[:background] + 40}m#{color_parameters[:uncolorized]}\033[0m".set_color_parameters(color_parameters)
   end
 
   #
@@ -127,37 +124,36 @@ class String
   #
   # Make some color and on_color methods
   #
-  COLORS.each_key do | key |
+  COLORS.each_key do |key|
     next if key == :default
 
     define_method key do
-      self.colorize( :color => key )
+      colorize(color: key)
     end
 
     define_method "on_#{key}" do
-      self.colorize( :background => key )
+      colorize(background: key)
     end
   end
 
   #
   # Methods for modes
   #
-  MODES.each_key do | key |
+  MODES.each_key do |key|
     next if key == :default
 
     define_method key do
-      self.colorize( :mode => key )
+      colorize(mode: key)
     end
   end
 
   class << self
-
     #
     # Return array of available modes used by colorize method
     #
     def modes
       keys = []
-      MODES.each_key do | key |
+      MODES.each_key do |key|
         keys << key
       end
       keys
@@ -168,7 +164,7 @@ class String
     #
     def colors
       keys = []
-      COLORS.each_key do | key |
+      COLORS.each_key do |key|
         keys << key
       end
       keys
@@ -177,16 +173,16 @@ class String
     #
     # Display color matrix with color names.
     #
-    def color_matrix( txt = "[X]" )
+    def color_matrix(txt = "[X]")
       size = String.colors.length
-      String.colors.each do | color |
-        String.colors.each do | back |
-          print txt.colorize( :color => color, :background => back )
+      String.colors.each do |color|
+        String.colors.each do |back|
+          print txt.colorize(color: color, background: back)
         end
         puts " < #{color}"
       end
-      String.colors.reverse.each_with_index do | back, index |
-        puts "#{"|".rjust(txt.length)*(size-index)} < #{back}"
+      String.colors.reverse.each_with_index do |back, index|
+        puts "#{"|".rjust(txt.length) * (size - index)} < #{back}"
       end
       ""
     end

--- a/lib/raygun/raygun.rb
+++ b/lib/raygun/raygun.rb
@@ -222,14 +222,14 @@ module Raygun
     def sed_i
       @sed_format ||= begin
         `sed --version &> /dev/null`
-        $CHILD_STATUS.success? ? "sed -i" : "sed -i ''"
+        $?.success? ? "sed -i" : "sed -i ''"
       end
     end
 
     # Run a shell command and raise an exception if it fails.
     def shell(command)
       `#{command}`
-      raise "#{command} failed with status #{$CHILD_STATUS.exitstatus}." unless $CHILD_STATUS.success?
+      raise "#{command} failed with status #{$?.exitstatus}." unless $?.success?
     end
 
     def self.parse(_args)

--- a/lib/raygun/template_repo.rb
+++ b/lib/raygun/template_repo.rb
@@ -3,7 +3,7 @@ module Raygun
     attr_reader :name, :branch, :tarball, :sha
 
     def initialize(repo)
-      @name, @branch = repo.split('#').map(&:strip)
+      @name, @branch = repo.split("#").map(&:strip)
       fetch
     end
 
@@ -11,6 +11,7 @@ module Raygun
 
     def fetch
       return if @branch && @sha
+
       @branch ? fetch_branches : fetch_tags
     end
 
@@ -19,12 +20,12 @@ module Raygun
       print "Whoops - need to try again!".colorize(:red)
       puts  ""
       print "We could not find (".colorize(:light_red)
-      print "#{name}".colorize(:white)
+      print name.to_s.colorize(:white)
       print "##{branch}".colorize(:white) if @branch
       print ") on github.".colorize(:light_red)
       puts  ""
       print "The response from github was a (".colorize(:light_red)
-      print "#{response.code}".colorize(:white)
+      print response.code.to_s.colorize(:white)
       puts  ") which I'm sure you can fix right up!".colorize(:light_red)
       puts  ""
       exit 1
@@ -35,7 +36,7 @@ module Raygun
       print "Whoops - need to try again!".colorize(:red)
       puts  ""
       print "We could not find any tags in the repo (".colorize(:light_red)
-      print "#{name}".colorize(:white)
+      print name.to_s.colorize(:white)
       print ") on github.".colorize(:light_red)
       puts  ""
       print "Raygun uses the 'largest' tag in a repository, where tags are sorted alphanumerically.".colorize(:light_red)
@@ -50,8 +51,8 @@ module Raygun
       response = http_get("https://api.github.com/repos/#{name}/branches/#{branch}")
       handle_github_error(response) unless response.code == "200"
       result = JSON.parse(response.body)
-      @sha = result['commit']['sha']
-      @tarball = result['_links']['html'].gsub(%r(/tree/#{branch}), "/archive/#{branch}.tar.gz")
+      @sha = result["commit"]["sha"]
+      @tarball = result["_links"]["html"].gsub(%r{/tree/#{branch}}, "/archive/#{branch}.tar.gz")
     end
 
     def fetch_tags
@@ -60,8 +61,8 @@ module Raygun
 
       result = JSON.parse(response.body).first
       handle_missing_tag_error unless result
-      @sha = result['commit']['sha']
-      @tarball = result['tarball_url']
+      @sha = result["commit"]["sha"]
+      @tarball = result["tarball_url"]
     end
 
     def http_get(url)
@@ -70,7 +71,7 @@ module Raygun
       http.use_ssl = true
       request      = Net::HTTP::Get.new(URI.encode(url))
 
-      response     = http.request(request)
+      response = http.request(request)
     end
   end
 end

--- a/raygun.gemspec
+++ b/raygun.gemspec
@@ -1,22 +1,20 @@
-# -*- encoding: utf-8 -*-
-
-File.expand_path('../lib', __FILE__).tap do |lib|
+File.expand_path("lib", __dir__).tap do |lib|
   $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 end
 
-require 'raygun/version'
+require "raygun/version"
 
 Gem::Specification.new do |gem|
   gem.name          = "raygun"
   gem.version       = Raygun::VERSION
   gem.authors       = ["Christian Nelson", "Jonah Williams", "Jason Wadsworth"]
   gem.email         = ["christian@carbonfive.com"]
-  gem.description   = %q{Carbon Five Rails application generator}
-  gem.summary       = %q{Generates and customizes Rails applications with Carbon Five best practices baked in.}
+  gem.description   = "Carbon Five Rails application generator"
+  gem.summary       = "Generates and customizes Rails applications with Carbon Five best practices baked in."
   gem.homepage      = "https://github.com/carbonfive/raygun"
-  gem.license       = 'MIT'
+  gem.license       = "MIT"
 
-  gem.files         = `git ls-files`.split($/)
+  gem.files         = `git ls-files`.split($INPUT_RECORD_SEPARATOR)
   gem.executables   = gem.files.grep(%r{^bin/}).map { |f| File.basename(f) }
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]


### PR DESCRIPTION
Problem
-------

Shouldn't we eat our own dog food?

This repo was way out of sync with our current rubocop conventions.

Solution
--------

Bring it up to speed.

Because we don't have `rubocop` in the project, this can be seen as
a one-time cleanup.  We can decide later if we want it more persistent.
But for now I did the following:

* Copy `.rubocop.yml` from `carbonfive/c5-conventions`
  ```bash
  curl https://raw.githubusercontent.com/carbonfive/c5-conventions/master/rubocop/rubocop.yml > .rubocop.yml
  ```
* Locally add `rubocop` and `rubocop-performance` gems
  ```bash
  gem install rubocop
  gem install rubocop-performance

  ```
* run it
  ```bash
  rubocop -a
  ```