### PR TITLE
Copy c5-conventions/rubocop.yml into the new app

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,4 +1,9 @@
 require "bundler/gem_tasks"
+require "rspec/core/rake_task"
 require "rubocop/rake_task"
 
 RuboCop::RakeTask.new
+
+RSpec::Core::RakeTask.new(:spec)
+
+task default: %i[rubocop spec]

--- a/raygun.gemspec
+++ b/raygun.gemspec
@@ -23,5 +23,6 @@ Gem::Specification.new do |gem|
 
   gem.add_development_dependency "bundler", "~> 2.0"
   gem.add_development_dependency "rake", "~> 13.0"
+  gem.add_development_dependency "rspec", "~> 3.9"
   gem.add_development_dependency "rubocop", "0.79.0"
 end

--- a/spec/raygun/raygun.rb
+++ b/spec/raygun/raygun.rb
@@ -1,0 +1,3 @@
+require_relative "../spec_helper"
+
+describe Raygun::Runner

--- a/spec/raygun/runner_spec.rb
+++ b/spec/raygun/runner_spec.rb
@@ -1,0 +1,27 @@
+require_relative "../spec_helper"
+require_relative "../../lib/raygun/raygun"
+
+describe Raygun::Runner do
+  describe "#fetch_rubocop_file" do
+    context "the repo is the standard carbonfive raygun-rails repo" do
+      before do
+        @runner = described_class.new("target/dir", "carbonfive/raygun-rails")
+        allow(URI).to receive(:open).and_return(StringIO.new("# rubocop contents"))
+        allow(IO).to receive(:write)
+        allow(@runner).to receive(:shell).and_return("GitSHAgoeshere")
+      end
+      it "inserts a copy of the rubocop file pulled from the carbonfive/c5-conventions repo" do
+        @runner.send(:fetch_rubocop_file)
+        expect(@runner).to have_received(:shell)
+          .with("git ls-remote https://github.com/carbonfive/c5-conventions master")
+        expect(URI).to have_received(:open)
+          .with("https://raw.githubusercontent.com/carbonfive/c5-conventions/master/rubocop/rubocop.yml")
+        expect(IO).to have_received(:write) do |path, contents|
+          expect(path).to eq(File.absolute_path("target/dir/.rubocop.yml"))
+          expect(contents).to include("@ GitSHA")
+          expect(contents).to include("# rubocop contents")
+        end
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,1 @@
+require "rspec"


### PR DESCRIPTION
Problem
--------

Our connection to the rubocop.yml file in https://github.com/carbonfive/c5-conventions seems fragile.

Updates to that repo will affect all consumers out in the world (who we don't know) and may cause issues with their app. We've already seen it affect 1 client project in house.

Solution
---------

By default, pull the `rubocop.yml` from `c5-conventions` at the time the
app is constructed and pin it.  This will disconnect the constructed app
from the possibly dynamic rubocop file.

Additionally, we add some commentary to the top of the file to indcate
the SHA which was the original pull and a note to suggest upgrading at
the developers' discretion.

Changes
-------

* by default, fetch the rubocop file from github and write it to the
newly created target app
* add rspec
* add a test for this new functionality (the pull of the rubocop from GitHub)
* make the default rake task run `rubocop` and `rspec`


Fixes #146