### PR TITLE
Require ruby 2.4 or greater

### DIFF
--- a/raygun.gemspec
+++ b/raygun.gemspec
@@ -21,6 +21,8 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
 
+  gem.required_ruby_version = "~> 2.4"
+
   gem.add_development_dependency "bundler", "~> 2.0"
   gem.add_development_dependency "rake", "~> 13.0"
 end


### PR DESCRIPTION
Problem
-------

Upcoming work which will introduce Rubocop will likely introduce
code changes that may not be supported for older versions of ruby.

Because ruby < 2.4 is officially EOL, we should be able to require at least 2.4.

Solution
--------

Require ruby >= 2.4 in the gemspec.

EOL Ruby : https://endoflife.software/programming-languages/server-side-scripting/ruby