### PR TITLE
Add rubocop rake task

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,98 @@
+AllCops:
+  DisplayCopNames: true
+  DisplayStyleGuide: true
+
+#
+# Ruby Cops
+#
+
+Layout/CaseIndentation:
+  Enabled: false
+
+Layout/FirstArrayElementIndentation:
+  EnforcedStyle: consistent
+
+Layout/HashAlignment:
+  Enabled: false
+
+Layout/LineLength:
+  Max: 120
+
+Layout/MultilineMethodCallIndentation:
+  EnforcedStyle: indented
+
+Lint/AmbiguousBlockAssociation:
+  Enabled: false
+
+Lint/ScriptPermission:
+  Exclude:
+    - "Rakefile"
+
+Metrics/AbcSize:
+  Max: 35
+  Exclude:
+    - "spec/**/*"
+
+Metrics/BlockLength:
+  CountComments: false
+  Max: 50
+  Exclude:
+    - "config/**/*"
+    - "spec/**/*"
+
+Metrics/ClassLength:
+  Max: 250
+  Exclude:
+    - "spec/**/*"
+
+Metrics/MethodLength:
+  Max: 25
+  Exclude:
+    - "db/migrate/*"
+    - "spec/**/*"
+
+Naming/PredicateName:
+  Enabled: false
+
+Security/YAMLLoad:
+  Enabled: false
+
+Style/BarePercentLiterals:
+  EnforcedStyle: percent_q
+
+Style/BlockDelimiters:
+  EnforcedStyle: braces_for_chaining
+
+Style/Documentation:
+  Enabled: false
+
+Style/EmptyMethod:
+  EnforcedStyle: expanded
+
+Style/FrozenStringLiteralComment:
+  EnforcedStyle: never
+
+Style/Lambda:
+  EnforcedStyle: literal
+
+Style/ModuleFunction:
+  EnforcedStyle: extend_self
+
+Style/MutableConstant:
+  Enabled: false
+
+Style/PreferredHashMethods:
+  Enabled: false
+
+Style/SpecialGlobalVars:
+  Enabled: false
+
+Style/StringLiterals:
+  EnforcedStyle: double_quotes
+
+Style/StringLiteralsInInterpolation:
+  EnforcedStyle: double_quotes
+
+Style/StructInheritance:
+  Enabled: true
+

--- a/Rakefile
+++ b/Rakefile
@@ -1,1 +1,4 @@
 require "bundler/gem_tasks"
+require "rubocop/rake_task"
+
+RuboCop::RakeTask.new

--- a/bin/raygun
+++ b/bin/raygun
@@ -1,10 +1,10 @@
 #!/usr/bin/env ruby
 
-File.expand_path('../../lib', __FILE__).tap do |lib|
+File.expand_path("../lib", __dir__).tap do |lib|
   $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 end
 
-require 'raygun/raygun'
+require "raygun/raygun"
 
 raygun = Raygun::Runner.parse(ARGV)
 

--- a/raygun.gemspec
+++ b/raygun.gemspec
@@ -23,4 +23,5 @@ Gem::Specification.new do |gem|
 
   gem.add_development_dependency "bundler", "~> 2.0"
   gem.add_development_dependency "rake", "~> 13.0"
+  gem.add_development_dependency "rubocop", "0.79.0"
 end


### PR DESCRIPTION
Problem
-------

More dog-fooding.  We want to promote the use of our carbonfive/c5-conventions
rubocop file.  Let's use it here.

Solution
--------

* Copy the carbonfive/c5-conventions `.rubocop.yml` into place
* Remove `rubocop-performance` because we don't *really* need it and
it'd require adding another gem dev depenency - seems overkill for it's
possible benefit on *this* project
* Add `lib/tasks` to `rakelib`
* Add `rubocop.rake` file to get the `rubocop` and `rubocop:autocorrect`
tasks
* Run rubocop:autocorrect which cleaned a few things in bin/raygun

NOTE
----

This repo is *still* not rubocop clean.  There are several
not-autofixable issues that could (should?) be addressed once this is
approved.