### PR TITLE
Address Rubocop non-autocorrectable issues

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,4 +1,5 @@
 AllCops:
+  TargetRubyVersion: 2.4
   DisplayCopNames: true
   DisplayStyleGuide: true
 

--- a/lib/colorize.rb
+++ b/lib/colorize.rb
@@ -46,14 +46,14 @@ class String
   #
   # Set color values in new string intance
   #
-  def set_color_parameters(params)
-    if params.instance_of?(Hash)
-      @color = params[:color]
-      @background = params[:background]
-      @mode = params[:mode]
-      @uncolorized = params[:uncolorized]
-      self
-    end
+  def color_parameters(params)
+    return unless params.instance_of?(Hash)
+
+    @color = params[:color]
+    @background = params[:background]
+    @mode = params[:mode]
+    @uncolorized = params[:uncolorized]
+    self
   end
 
   public
@@ -74,6 +74,7 @@ class String
   #   puts "This is blue text on red".blue.on_red.blink
   #   puts "This is uncolorized".blue.on_red.uncolorize
   #
+  # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
   def colorize(params)
     return self unless STDOUT.isatty
 
@@ -104,8 +105,11 @@ class String
 
     color_parameters[:background] += 50 if color_parameters[:background] > 10
 
-    "\033[#{color_parameters[:mode]};#{color_parameters[:color] + 30};#{color_parameters[:background] + 40}m#{color_parameters[:uncolorized]}\033[0m".set_color_parameters(color_parameters)
+    "\033[#{color_parameters[:mode]};#{color_parameters[:color] + 30};"\
+    "#{color_parameters[:background] + 40}m#{color_parameters[:uncolorized]}\033[0m"\
+      .color_parameters(color_parameters)
   end
+  # rubocop:enable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
 
   #
   # Return uncolorized string

--- a/lib/raygun/template_repo.rb
+++ b/lib/raygun/template_repo.rb
@@ -39,7 +39,8 @@ module Raygun
       print name.to_s.colorize(:white)
       print ") on github.".colorize(:light_red)
       puts  ""
-      print "Raygun uses the 'largest' tag in a repository, where tags are sorted alphanumerically.".colorize(:light_red)
+      print "Raygun uses the 'largest' tag in a repository, " \
+            "where tags are sorted alphanumerically.".colorize(:light_red)
       puts  ""
       print "E.g., tag 'v.0.10.0' > 'v.0.9.9' and 'x' > 'a'.".colorize(:light_red)
       print ""
@@ -66,12 +67,12 @@ module Raygun
     end
 
     def http_get(url)
-      uri          = URI.parse(url)
+      uri          = URI(url)
       http         = Net::HTTP.new(uri.host, uri.port)
       http.use_ssl = true
-      request      = Net::HTTP::Get.new(URI.encode(url))
+      request      = Net::HTTP::Get.new(uri)
 
-      response = http.request(request)
+      http.request(request)
     end
   end
 end


### PR DESCRIPTION
* Remove URI.encode, which is deprecated in Ruby 2.7 (from https://github.com/carbonfive/raygun/pull/145)
* Address Rubocop warnings