### PR TITLE
Add bin/setup script and development instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,9 +148,17 @@ prototype (which is a valid rails app) and tag them when they should be used for
 
 ### Development
 
-Generate an example app using your local development version of Raygun:
+To set up your local environment, run:
 
-    $ ./bin/raygun tmp/example_app
+    $ bin/setup
+
+To run tests and rubocop checks:
+
+    $ bundle exec rake
+
+To generate an example app using your local development version of Raygun:
+
+    $ bin/raygun tmp/example_app
 
 ## Changes
 

--- a/bin/setup
+++ b/bin/setup
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+IFS=$'\n\t'
+set -vx
+
+bundle install


### PR DESCRIPTION
As is tradition for Rails and gem codebases, add a `bin/setup` script to bootstrap a developer's local environment. For raygun this is just a matter of running `bundle install`. I took this script from the standard gem template published by the bundler project:

https://github.com/rubygems/bundler/blob/203d02c3670083a95733afc1a9d7a870d1ae1c34/lib/bundler/templates/newgem/bin/setup.tt

Also modify the README to mention `bin/setup` and explain how to run tests and rubocop.