### PR TITLE
Rename master branch to "main"

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![Gem Version](https://badge.fury.io/rb/raygun.svg)](http://badge.fury.io/rb/raygun)
-<img src="https://raw.github.com/carbonfive/raygun/master/marvin.jpg" align="right"/>
+<img src="https://raw.github.com/carbonfive/raygun/main/marvin.jpg" align="right"/>
 
 # Raygun
 
@@ -162,4 +162,4 @@ To generate an example app using your local development version of Raygun:
 
 ## Changes
 
-[View the Change Log](https://github.com/carbonfive/raygun/tree/master/CHANGES.md)
+[View the Change Log](https://github.com/carbonfive/raygun/tree/main/CHANGES.md)

--- a/lib/raygun/raygun.rb
+++ b/lib/raygun/raygun.rb
@@ -154,6 +154,7 @@ module Raygun
     def initialize_git
       Dir.chdir(app_dir) do
         shell "git init"
+        shell "git checkout -q -b main"
         shell "git add -A ."
         shell "git commit -m 'Raygun-zapped skeleton.'"
       end


### PR DESCRIPTION
This commit updates the raygun docs to reflect "main" as the new default branch name for this repo (replacing "master").

Additionally, when raygun "zaps" a new project, it will now initialize the git repo of the new project with "main" as the default branch name. This is done by calling:

```
git checkout -b main
```

After the repo is initialized. This works because a freshly init-ed repo does not have any branches, so the act of creating a branch implicitly makes it the default.