### PR TITLE
Remove unused spec file

### DIFF
--- a/spec/raygun/raygun.rb
+++ b/spec/raygun/raygun.rb
@@ -1,3 +1,0 @@
-require_relative "../spec_helper"
-
-describe Raygun::Runner


### PR DESCRIPTION
There was a `raygun.rb` file that seems to be an empty stub for testing `Raygun::Runner`. But the tests for `Raygun::Runner` are actually in `spec/raygun/runner_spec.rb` (as expected). So `raygun.rb` isn't being used for anything. We can safely remove it.