### PR TITLE
Document how to add React and Typescript

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,35 @@ $ open http://localhost:3000
 
 ## Next Steps
 
+### React
+
+To add React, just run this generator:
+
+```bash
+$ bundle exec rails webpacker:install:react
+```
+
+You can use JSX in your `app/javascript` sources and the `react_component` helper in your Rails views. Your React code
+will be packaged and deployed automatically with the rest of your app, and you can test it end-to-end with Capybara,
+just like other Rails apps. See the [webpacker-react](https://github.com/renchap/webpacker-react) README for more
+information.
+
+> :bulb: Check out [spraygun-react](https://github.com/carbonfive/spraygun-react) for eslint and stylelint configurations that can work for React projects.
+
+### React with Typescript
+
+To add React with Typescript, run the React generator listed above, and then add Typescript:
+
+```bash
+$ bundle exec rails webpacker:install:typescript
+```
+
+Don't forget to rename any files containing JSX to `.tsx`.
+
+For more information, see the [webpacker Typescript docs](https://github.com/rails/webpacker/blob/master/docs/typescript.md).
+
+### Bootstrap
+
 As you'll notice, the project comes with enough CSS (SCSS, actually) to establish some patterns.  If you
 need more of a framework, here are instructions on how to add Bootstrap to your new project.
 

--- a/lib/raygun/raygun.rb
+++ b/lib/raygun/raygun.rb
@@ -203,10 +203,10 @@ module Raygun
       puts "$".colorize(:blue) + " bin/rake".colorize(:light_blue)
       puts ""
       puts "# Run the app and check things out".colorize(:light_green)
-      puts "$".colorize(:blue) + " heroku local".colorize(:light_blue)
+      puts "$".colorize(:blue) + " yarn start".colorize(:light_blue)
       puts "$".colorize(:blue) + " open http://localhost:3000".colorize(:light_blue)
       puts ""
-      puts "# For some suggested next steps, check out the raygun README".colorize(:light_green)
+      puts "# For next steps like adding Bootstrap or React, check out the raygun README".colorize(:light_green)
       puts "$".colorize(:blue) + " open https://github.com/carbonfive/raygun/#next-steps".colorize(:light_blue)
       puts ""
       puts "Enjoy your Carbon Five flavored Rails application!".colorize(:yellow)


### PR DESCRIPTION
Apps generated with raygun don't include React or Typescript out of the box, but these are often a natural next step.

Adding React and Typescript to Rails is simple with webpacker, but this is not widely known. Help developers who may be adding React or Typescript to a webpacker project for the first time by documenting it in the raygun README.

Also call out React in the next steps that are printed by raygun.