### PR TITLE
Support any supported version of ruby

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -63,4 +63,4 @@ workflows:
       - rspec:
           matrix:
             parameters:
-              version: ["2.5.8", "2.6.6", "2.7.2"]
+              version: ["2.5.8", "2.6.6", "2.7.2", "3.0.0"]

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,5 @@
 AllCops:
-  TargetRubyVersion: 2.4
+  TargetRubyVersion: 2.5
   DisplayCopNames: true
   DisplayStyleGuide: true
 

--- a/raygun.gemspec
+++ b/raygun.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = "~> 2.4"
+  gem.required_ruby_version = ">= 2.5"
 
   gem.add_development_dependency "bundler", "~> 2.0"
   gem.add_development_dependency "rake", "~> 13.0"


### PR DESCRIPTION
The latest version of raygun that installs under Ruby 3.0 is 1.0.4 because of the constraint in the gemspec.

Ruby 2.5 is the oldest supported version. This allows any version 2.5 or newer to be used.