### PR TITLE
Fix typo in README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ If you invoke raygun with the `-p` option, you can specify your own github repos
 
 Or
 
-    $ raygun -p githubid/repo your-project#new-branch-name
+    $ raygun -p githubid/repo#some-template-branch your-project
 
 The repository must:
 


### PR DESCRIPTION
# Problem

The example showing how to specify a branch for your template had the branch name in the wrong place.

# Solution

Fix typo